### PR TITLE
Enable parsing share-usage metadata for shared module tree shaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,6 +4806,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash 2.1.1",
+ "serde",
  "serde_json",
  "sugar_path",
  "swc_core",

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -844,6 +844,10 @@ impl From<JsBuildMeta> for BuildMeta {
       default_object,
       side_effect_free,
       exports_final_name,
+      consume_shared_key: None,
+      shared_key: None,
+      is_shared_descendant: None,
+      effective_shared_key: None,
     }
   }
 }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -36,6 +36,7 @@ rspack_regex = { workspace = true }
 rspack_util = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 sugar_path = { workspace = true }
 swc_core = { workspace = true, features = [
   "__parser",

--- a/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/index.js
+++ b/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/index.js
@@ -1,0 +1,6 @@
+const mod = require("./module");
+
+it("should tree shake unused exports in shared modules", () => {
+  expect(mod.used).toBe(42);
+  expect(mod.unused).toBe(undefined);
+});

--- a/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/module.js
+++ b/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/module.js
@@ -1,0 +1,2 @@
+export const used = 42;
+export const unused = 1;

--- a/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/share-usage.json
+++ b/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/share-usage.json
@@ -1,0 +1,9 @@
+{
+  "treeShake": {
+    "module": {
+      "used": true,
+      "unused": false,
+      "chunkCharacteristics": {}
+    }
+  }
+}

--- a/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/webpack.config.js
+++ b/tests/webpack-test/configCases/sharing/consume-shared-tree-shaking/webpack.config.js
@@ -1,0 +1,19 @@
+const { ProvideSharedPlugin } = require("@rspack/core").sharing;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: "production",
+  optimization: {
+    usedExports: true,
+  },
+  plugins: [
+    new ProvideSharedPlugin({
+      provides: {
+        "./module": {
+          shareKey: "module",
+          version: "1.0.0",
+        },
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary
- parse `share-usage.json` during flag dependency usage to mark used exports for shared modules
- initialize new Module Federation fields in binding API build metadata
- mark unused shared exports as `Unused` when applying `share-usage.json`
- follow HTTP redirects iteratively in the schemes plugin to avoid non-Send recursive futures

## Testing
- `RUSTUP_TOOLCHAIN=nightly pnpm build:cli:dev`
- `RUSTUP_TOOLCHAIN=nightly cargo test -p rspack_plugin_schemes --no-run`
- `cd tests/webpack-test && RUSTUP_TOOLCHAIN=nightly pnpm exec cross-env NODE_OPTIONS="--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation" jest --runTestsByPath ConfigTestCases.basictest.js -t consume-shared-tree-shaking`


------
https://chatgpt.com/codex/tasks/task_e_689c19c48714832588e81bfdf227ae6c